### PR TITLE
Add a method to check if a signal with the given name exists.

### DIFF
--- a/include/dynamic-graph/entity.h
+++ b/include/dynamic-graph/entity.h
@@ -84,6 +84,7 @@ namespace dynamicgraph
     }
     virtual const std::string& getClassName  () const = 0;
     virtual std::string getDocString () const;
+    bool hasSignal( const std::string & signame ) const;
     SignalBase<int>& getSignal (const std::string& signalName);
     const SignalBase<int>& getSignal (const std::string& signalName) const;
     std::ostream& displaySignalList(std::ostream& os) const;

--- a/src/dgraph/entity.cpp
+++ b/src/dgraph/entity.cpp
@@ -149,6 +149,11 @@ std::string Entity::getDocString () const
   return *(sigkey ->second) ;
 
 
+bool Entity::
+hasSignal( const string & signame ) const
+{
+  return (!(signalMap.find(signame) == signalMap.end ()));
+}
 
 SignalBase<int>& Entity::
 getSignal( const string & signame )


### PR DESCRIPTION
The goal of this commit is to add a way to know if a signal exists in an entity without retrieving this signal.
Especially in the python interface, I didn't find a way to have this information unless by getting the signal, and catching the exception if the signal does not exist.

This can be useful for the entities that can create signals on the fly.
