### PR TITLE
Fix PoolStorage destructor

### DIFF
--- a/include/dynamic-graph/contiifstream.h
+++ b/include/dynamic-graph/contiifstream.h
@@ -18,7 +18,6 @@
 #ifndef DYNAMIC_GRAPH_CONTIIFSTREAM_H
 # define DYNAMIC_GRAPH_CONTIIFSTREAM_H
 # include <fstream>
-# include <iostream>
 # include <list>
 # include <sstream>
 

--- a/include/dynamic-graph/debug.h
+++ b/include/dynamic-graph/debug.h
@@ -188,13 +188,13 @@ inline bool dgTDEBUG_ENABLE (const int & level)
   if (1)					\
     ;						\
   else						\
-    std::ostream(NULL)
+    ::dynamicgraph::__null_stream()
 
 #  define dgDEBUGMUTE (level)			\
   if (1)					\
     ;						\
   else						\
-    std::ostream(NULL)
+    ::dynamicgraph::__null_stream()
 
 #  define dgERROR				\
   dgERRORFLOW.outputbuffer << dgPREERROR
@@ -219,12 +219,23 @@ inline void dgERRORF (const char*, ...)
   return;
 }
 
+namespace dynamicgraph
+{
+inline std::ostream& __null_stream ()
+{
+  // This function should never be called. With -O3,
+  // it should not appear in the generated binary.
+  static std::ostream os (NULL); return os;
+}
+}
+
+
 // TEMPLATE
 #  define dgTDEBUG(level)			\
   if (1)					\
     ;						\
   else						\
-    std::ostream(NULL)
+    ::dynamicgraph::__null_stream()
 
 inline void dgTDEBUGF (const int, const char*, ...)
 {

--- a/include/dynamic-graph/debug.h
+++ b/include/dynamic-graph/debug.h
@@ -19,7 +19,6 @@
 # define DYNAMIC_GRAPH_DEBUG_HH
 # include <cstdio>
 # include <cstdarg>
-# include <iostream>
 # include <fstream>
 # include <sstream>
 
@@ -189,13 +188,13 @@ inline bool dgTDEBUG_ENABLE (const int & level)
   if (1)					\
     ;						\
   else						\
-    std::cout
+    std::ostream(NULL)
 
 #  define dgDEBUGMUTE (level)			\
   if (1)					\
     ;						\
   else						\
-    std::cout
+    std::ostream(NULL)
 
 #  define dgERROR				\
   dgERRORFLOW.outputbuffer << dgPREERROR
@@ -225,7 +224,7 @@ inline void dgERRORF (const char*, ...)
   if (1)					\
     ;						\
   else						\
-    std::cout
+    std::ostream(NULL)
 
 inline void dgTDEBUGF (const int, const char*, ...)
 {

--- a/include/dynamic-graph/eigen-io.h
+++ b/include/dynamic-graph/eigen-io.h
@@ -18,7 +18,6 @@
 #ifndef DYNAMIC_GRAPH_EIGEN_IO_H
 #define DYNAMIC_GRAPH_EIGEN_IO_H
 
-#include <iostream>
 #include <boost/format.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 

--- a/include/dynamic-graph/exception-abstract.h
+++ b/include/dynamic-graph/exception-abstract.h
@@ -17,7 +17,6 @@
 
 #ifndef DYNAMIC_GRAPH_EXCEPTION_ABSTRACT_H
 # define DYNAMIC_GRAPH_EXCEPTION_ABSTRACT_H
-# include <iostream>
 # include <string>
 
 # include <dynamic-graph/fwd.hh>

--- a/include/dynamic-graph/signal-base.h
+++ b/include/dynamic-graph/signal-base.h
@@ -19,7 +19,6 @@
 # define DYNAMIC_GRAPH_SIGNAL_BASE_H
 # include <string>
 # include <sstream>
-# include <iostream>
 # include <typeinfo>
 # include <boost/noncopyable.hpp>
 

--- a/include/dynamic-graph/signal-cast-helper.h
+++ b/include/dynamic-graph/signal-cast-helper.h
@@ -18,7 +18,6 @@
 # define DYNAMIC_GRAPH_SIGNAL_CASTER_HELPER_HH
 # include <map>
 # include <typeinfo>
-# include <iostream>
 # include <vector>
 
 # include <boost/any.hpp>

--- a/include/dynamic-graph/signal-caster.h
+++ b/include/dynamic-graph/signal-caster.h
@@ -18,7 +18,6 @@
 # define DYNAMIC_GRAPH_SIGNAL_CASTER_HH
 # include <map>
 # include <typeinfo>
-# include <iostream>
 # include <vector>
 
 # include <boost/any.hpp>

--- a/include/dynamic-graph/signal-ptr.h
+++ b/include/dynamic-graph/signal-ptr.h
@@ -17,10 +17,11 @@
 
 #ifndef DYNAMIC_GRAPH_SIGNAL_PTR_H
 #define DYNAMIC_GRAPH_SIGNAL_PTR_H
-# include <iostream>
 
 # include <dynamic-graph/exception-signal.h>
 # include <dynamic-graph/signal.h>
+
+# include <dynamic-graph/deprecated.hh>
 
 namespace dynamicgraph
 {
@@ -73,9 +74,7 @@ namespace dynamicgraph
     const SignalBase<Time>* getAbstractPtr () const; // throw
     virtual void plug( SignalBase<Time>* ref );
     virtual void unplug () { plug(NULL); }
-    virtual bool isPluged () const {
-      std::cerr << "The method isPluged is deprecated.";
-      std::cerr << " Please use isPlugged instead" << std::endl;
+    virtual bool isPluged () const DYNAMIC_GRAPH_DEPRECATED {
       return isPlugged ();
     }
     virtual bool isPlugged () const { return (NULL!=signalPtr); }

--- a/include/dynamic-graph/signal.h
+++ b/include/dynamic-graph/signal.h
@@ -25,7 +25,6 @@
 #include <boost/function.hpp>
 
 #include <string>
-#include <iostream>
 
 #include <dynamic-graph/exception-signal.h>
 #include <dynamic-graph/signal-base.h>

--- a/include/dynamic-graph/time-dependency.h
+++ b/include/dynamic-graph/time-dependency.h
@@ -18,7 +18,6 @@
 #ifndef DYNAMIC_GRAPH_TIME_DEPENDENCY_H
 # define DYNAMIC_GRAPH_TIME_DEPENDENCY_H
 # include <list>
-# include <iostream>
 
 # include <dynamic-graph/fwd.hh>
 # include <dynamic-graph/signal-base.h>

--- a/include/dynamic-graph/value.h
+++ b/include/dynamic-graph/value.h
@@ -18,7 +18,6 @@
 #ifndef DYNAMIC_GRAPH_VALUE_H
 #define DYNAMIC_GRAPH_VALUE_H
 
-#include <iostream>
 #include <string>
 #include <cassert>
 #include <typeinfo>

--- a/src/dgraph/pool.cpp
+++ b/src/dgraph/pool.cpp
@@ -25,7 +25,6 @@
 /* --- DYNAMIC-GRAPH --- */
 #include <list>
 #include <typeinfo>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include "dynamic-graph/pool.h"

--- a/src/dgraph/pool.cpp
+++ b/src/dgraph/pool.cpp
@@ -65,7 +65,6 @@ PoolStorage::
       dgDEBUG(15) << "Delete \""
 		   << (iter->first) <<"\""<<std::endl;
       Entity* entity = iter->second;
-      deregisterEntity(iter);
       delete (entity);
     }
   instance_ = 0;


### PR DESCRIPTION
Erasing a iterator from a map invalidates it so next call to `iter++` has undefined behavior.