### PR TITLE
[signal] Fix the macros declaring signals

### DIFF
--- a/include/dynamic-graph/signal-helper.h
+++ b/include/dynamic-graph/signal-helper.h
@@ -30,14 +30,14 @@
 /* --- MACROS ---------------------------------------------------------- */
 #define SIGNAL_OUT_FUNCTION_NAME(name) name##SOUT_function
 
-#define DECLARE_SIGNAL( name,IO,type )    ::dynamicgraph::Signal<type,int> name##S##IO
-#define CONSTRUCT_SIGNAL( name,IO,type )  name##S##IO( getClassName()+"("+getName()+")::"+#IO+"put("+#type+")::"+#name )
+#define DECLARE_SIGNAL( name,IO,type )    ::dynamicgraph::Signal<type,int> m_##name##S##IO
+#define CONSTRUCT_SIGNAL( name,IO,type )  m_##name##S##IO( getClassName()+"("+getName()+")::"+#IO+"put("+#type+")::"+#name )
 #define BIND_SIGNAL_TO_FUNCTION(name,IO,type) m_##name##S##IO.setFunction(boost::bind(&EntityClassName::SIGNAL_OUT_FUNCTION_NAME(name),this,_1,_2));
 
 /**/
 
-#define DECLARE_SIGNAL_IN( name,type )    ::dynamicgraph::SignalPtr<type,int> name##SIN
-#define CONSTRUCT_SIGNAL_IN( name,type )  name##SIN( NULL,getClassName()+"("+getName()+")::input("+#type+")::"+#name )
+#define DECLARE_SIGNAL_IN( name,type )    ::dynamicgraph::SignalPtr<type,int> m_##name##SIN
+#define CONSTRUCT_SIGNAL_IN( name,type )  m_##name##SIN( NULL,getClassName()+"("+getName()+")::input("+#type+")::"+#name )
 
 /**/
 
@@ -51,12 +51,12 @@
 
 #define DECLARE_SIGNAL_OUT( name,type )                         \
   public:                                                       \
-    ::dynamicgraph::SignalTimeDependent<type,int> name##SOUT;	\
+    ::dynamicgraph::SignalTimeDependent<type,int> m_##name##SOUT;	\
   protected:                                                    \
   type& SIGNAL_OUT_FUNCTION(name)( type&,int )
 
 #define CONSTRUCT_SIGNAL_OUT( name,type,dep )		\
-  name##SOUT( boost::bind(&  EntityClassName::name##SOUT_function,this,_1,_2), \
+  m_##name##SOUT( boost::bind(&  EntityClassName::name##SOUT_function,this,_1,_2), \
 	      dep,getClassName()+"("+getName()+")::output("+#type+")::"+#name )
 
 


### PR DESCRIPTION
Pull-request linked to the `robot_utils` tool of sot-core based on `common` from sot-torque-control.

Changing the following macros:
DECLARE_SIGNAL_IN, CONSTRUCT_SIGNAL_IN, DECLARE_SIGNAL_OUT and CONSTRUCT_SIGNAL_OUT

The macros were duplicated in various SoT packages.
Unify them by:
* Adding prefix m_ and suffix SIN for input signals
declared as fields of entity classes.
* Adding prefix m_ and suffix SOUT for output signals
declared as fields of entity classes.

WARNING: This convention is not used in all packages.
Some duplicated macros don't use the m_ (for instance in sot-core and sot-dyninv).