### PR TITLE
Improve string typed signals

### DIFF
--- a/src/signal/signal-cast-helper.cpp
+++ b/src/signal/signal-cast-helper.cpp
@@ -84,6 +84,14 @@ inline boost::any DefaultCastRegisterer<std::string>::cast
   return inst;
 }
 
+// for std::string, do not add std::endl at the end of the stream.
+template <>
+inline void DefaultCastRegisterer<std::string>::disp
+(const boost::any &object, std::ostream &os)
+{
+  os << boost::any_cast<std::string>(object);
+}
+
 /// Registers useful casts
 namespace {
 DefaultCastRegisterer<double> double_reg;

--- a/src/signal/signal-cast-helper.cpp
+++ b/src/signal/signal-cast-helper.cpp
@@ -73,6 +73,17 @@ void DefaultCastRegisterer<dynamicgraph::Matrix>::trace(
     }
 }
 
+// for std::string, do not check failure. If input stream contains an
+// empty string, iss.fail() returns true and an exception is thrown
+template <>
+inline boost::any DefaultCastRegisterer<std::string>::cast
+(std::istringstream &iss)
+{
+  std::string inst ("");
+  iss >> inst;
+  return inst;
+}
+
 /// Registers useful casts
 namespace {
 DefaultCastRegisterer<double> double_reg;

--- a/src/signal/signal-cast-helper.cpp
+++ b/src/signal/signal-cast-helper.cpp
@@ -79,8 +79,7 @@ template <>
 inline boost::any DefaultCastRegisterer<std::string>::cast
 (std::istringstream &iss)
 {
-  std::string inst ("");
-  iss >> inst;
+  std::string inst (iss.str ());
   return inst;
 }
 

--- a/tests/signal-ptr.cpp
+++ b/tests/signal-ptr.cpp
@@ -86,3 +86,19 @@ BOOST_AUTO_TEST_CASE(normal_test) {
   sigPtrBRef.get(cout);
   cout << std::endl;
 }
+
+BOOST_AUTO_TEST_CASE (plug_signal_string)
+{
+  Signal<std::string, int> outSig("output");
+  SignalPtr<std::string, int> inSig (NULL, "input");
+
+  std::string str ("value");
+  outSig.setConstant(str);
+  inSig.plug (&outSig);
+  inSig.recompute(1);
+  std::ostringstream os;
+  inSig.get (os);
+  std::string res (os.str ());
+  // Note that a '\n' is added when passing through the signal
+  BOOST_CHECK (res == str);
+}

--- a/tests/signal-ptr.cpp
+++ b/tests/signal-ptr.cpp
@@ -99,6 +99,5 @@ BOOST_AUTO_TEST_CASE (plug_signal_string)
   std::ostringstream os;
   inSig.get (os);
   std::string res (os.str ());
-  // Note that a '\n' is added when passing through the signal
   BOOST_CHECK (res == str);
 }

--- a/tests/signal-ptr.cpp
+++ b/tests/signal-ptr.cpp
@@ -92,12 +92,21 @@ BOOST_AUTO_TEST_CASE (plug_signal_string)
   Signal<std::string, int> outSig("output");
   SignalPtr<std::string, int> inSig (NULL, "input");
 
-  std::string str ("value");
+  std::string str ("two words");
   outSig.setConstant(str);
   inSig.plug (&outSig);
   inSig.recompute(1);
-  std::ostringstream os;
-  inSig.get (os);
-  std::string res (os.str ());
+  std::ostringstream os1;
+  inSig.get (os1);
+  std::string res (os1.str ());
+  BOOST_CHECK (res == str);
+
+  Signal<std::string, int> s ("signal");
+  std::ostringstream os2;
+  s.setConstant (str);
+  os2.clear ();
+  s.get (os2);
+  res = os2.str ();
+  std::cout << "res=" << res << std::endl;
   BOOST_CHECK (res == str);
 }


### PR DESCRIPTION
 1. reimplement DefaultCastRegister<std::string>::cast and disp in order
    - not to add a '\n' at the end of the string,
    - not fail is empty string is stored in the signal.
 2. add a test to test signal plugging.
  