### PR TITLE
Fix Signal<std::string>

### DIFF
--- a/src/signal/signal-cast-helper.cpp
+++ b/src/signal/signal-cast-helper.cpp
@@ -52,6 +52,15 @@ inline boost::any DefaultCastRegisterer<double>::cast(std::istringstream &iss) {
   }
 }
 
+// for std::string, do not check failure. If input stream contains an
+// empty string, iss.fail() returns true and an exception is thrown
+template <>
+inline boost::any
+DefaultCastRegisterer<std::string>::cast(std::istringstream &iss) {
+  std::string inst(iss.str());
+  return inst;
+}
+
 // for std::string, do not add std::endl at the end of the stream.
 template <>
 inline void DefaultCastRegisterer<std::string>::disp(const boost::any &object,

--- a/tests/signal-ptr.cpp
+++ b/tests/signal-ptr.cpp
@@ -297,3 +297,19 @@ BOOST_AUTO_TEST_CASE(plug_signal_string) {
   std::cout << "res=" << res << std::endl;
   BOOST_CHECK(res == str);
 }
+
+BOOST_AUTO_TEST_CASE(set_signal_string) {
+  Signal<std::string, int> s("signal");
+  std::string str("");
+  std::ostringstream os;
+  os << str;
+  std::istringstream value(os.str());
+  try {
+    s.set(value);
+  }
+  catch(const std::exception& exc)
+  {
+    std::cout << exc.what() << std::endl;
+    BOOST_CHECK(!"Tentative to set signal to empty string");
+  }
+}


### PR DESCRIPTION
Commit 5daf1d39 introduced a bug when trying to set the value of a signal of type string to empty string.
This commit

- fixes the issue,

- adds a test.
