### PR TITLE
This PR fixes an ambiguity of ```unsigned long``` on clang/macOS

### DIFF
--- a/include/dynamic-graph/command-setter.t.cpp
+++ b/include/dynamic-graph/command-setter.t.cpp
@@ -106,7 +106,7 @@ class Setter<E, uint64_t> : public Command {
 
 template <class E>
 Setter<E, uint64_t>::Setter(E &entity, SetterMethod setterMethod,
-                                 const std::string &docString)
+                            const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::UNSIGNEDLONGINT),
               docString),
       setterMethod_(setterMethod) {}

--- a/include/dynamic-graph/command-setter.t.cpp
+++ b/include/dynamic-graph/command-setter.t.cpp
@@ -90,10 +90,10 @@ Value Setter<E, unsigned>::doExecute() {
 // Template specialization: unsigned long
 //
 template <class E>
-class Setter<E, unsigned long> : public Command {
+class Setter<E, uint64_t> : public Command {
  public:
   /// Pointer to method that sets parameter of type unsigned long
-  typedef void (E::*SetterMethod)(const unsigned long &);
+  typedef void (E::*SetterMethod)(const uint64_t &);
   /// Constructor
   Setter(E &entity, SetterMethod setterMethod, const std::string &docString);
 
@@ -105,17 +105,17 @@ class Setter<E, unsigned long> : public Command {
 };  // Class Setter
 
 template <class E>
-Setter<E, unsigned long>::Setter(E &entity, SetterMethod setterMethod,
+Setter<E, uint64_t>::Setter(E &entity, SetterMethod setterMethod,
                                  const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::UNSIGNEDLONGINT),
               docString),
       setterMethod_(setterMethod) {}
 
 template <class E>
-Value Setter<E, unsigned long>::doExecute() {
+Value Setter<E, uint64_t>::doExecute() {
   const std::vector<Value> &values = getParameterValues();
   // Get parameter
-  unsigned long value = values[0].value();
+  uint64_t value = values[0].value();
   E &entity = static_cast<E &>(owner());
   (entity.*setterMethod_)(value);
   return Value();

--- a/include/dynamic-graph/command-setter.t.cpp
+++ b/include/dynamic-graph/command-setter.t.cpp
@@ -90,10 +90,10 @@ Value Setter<E, unsigned>::doExecute() {
 // Template specialization: unsigned long
 //
 template <class E>
-class Setter<E, uint64_t> : public Command {
+class Setter<E, std::uint64_t> : public Command {
  public:
   /// Pointer to method that sets parameter of type unsigned long
-  typedef void (E::*SetterMethod)(const uint64_t &);
+  typedef void (E::*SetterMethod)(const std::uint64_t &);
   /// Constructor
   Setter(E &entity, SetterMethod setterMethod, const std::string &docString);
 
@@ -105,17 +105,17 @@ class Setter<E, uint64_t> : public Command {
 };  // Class Setter
 
 template <class E>
-Setter<E, uint64_t>::Setter(E &entity, SetterMethod setterMethod,
+Setter<E, std::uint64_t>::Setter(E &entity, SetterMethod setterMethod,
                             const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::UNSIGNEDLONGINT),
               docString),
       setterMethod_(setterMethod) {}
 
 template <class E>
-Value Setter<E, uint64_t>::doExecute() {
+Value Setter<E, std::uint64_t>::doExecute() {
   const std::vector<Value> &values = getParameterValues();
   // Get parameter
-  uint64_t value = values[0].value();
+  std::uint64_t value = values[0].value();
   E &entity = static_cast<E &>(owner());
   (entity.*setterMethod_)(value);
   return Value();
@@ -159,10 +159,10 @@ Value Setter<E, int>::doExecute() {
 // Template specialization: int64_t
 //
 template <class E>
-class Setter<E, int64_t> : public Command {
+class Setter<E, std::int64_t> : public Command {
  public:
   /// Pointer to method that sets parameter of type int64_t
-  typedef void (E::*SetterMethod)(const int64_t &);
+  typedef void (E::*SetterMethod)(const std::int64_t &);
   /// Constructor
   Setter(E &entity, SetterMethod setterMethod, const std::string &docString);
 
@@ -174,16 +174,16 @@ class Setter<E, int64_t> : public Command {
 };  // Class Setter
 
 template <class E>
-Setter<E, int64_t>::Setter(E &entity, SetterMethod setterMethod,
+Setter<E, std::int64_t>::Setter(E &entity, SetterMethod setterMethod,
                            const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::LONGINT), docString),
       setterMethod_(setterMethod) {}
 
 template <class E>
-Value Setter<E, int64_t>::doExecute() {
+Value Setter<E, std::int64_t>::doExecute() {
   const std::vector<Value> &values = getParameterValues();
   // Get parameter
-  int64_t value = values[0].value();
+  std::int64_t value = values[0].value();
   E &entity = static_cast<E &>(owner());
   (entity.*setterMethod_)(value);
   return Value();

--- a/include/dynamic-graph/command-setter.t.cpp
+++ b/include/dynamic-graph/command-setter.t.cpp
@@ -106,7 +106,7 @@ class Setter<E, std::uint64_t> : public Command {
 
 template <class E>
 Setter<E, std::uint64_t>::Setter(E &entity, SetterMethod setterMethod,
-                            const std::string &docString)
+                                 const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::UNSIGNEDLONGINT),
               docString),
       setterMethod_(setterMethod) {}
@@ -175,7 +175,7 @@ class Setter<E, std::int64_t> : public Command {
 
 template <class E>
 Setter<E, std::int64_t>::Setter(E &entity, SetterMethod setterMethod,
-                           const std::string &docString)
+                                const std::string &docString)
     : Command(entity, boost::assign::list_of(Value::LONGINT), docString),
       setterMethod_(setterMethod) {}
 

--- a/include/dynamic-graph/value.h
+++ b/include/dynamic-graph/value.h
@@ -9,6 +9,7 @@
 
 #include <dynamic-graph/linear-algebra.h>
 
+#include <cstdint>
 #include <cassert>
 #include <string>
 #include <typeinfo>
@@ -26,10 +27,10 @@ class DYNAMIC_GRAPH_DLLAPI EitherType {
   EitherType(const Value &value);
   ~EitherType();
   operator bool() const;
-  operator uint32_t() const;
-  operator uint64_t() const;
-  operator int32_t() const;
-  operator int64_t() const;
+  operator std::uint32_t() const;
+  operator std::uint64_t() const;
+  operator std::int32_t() const;
+  operator std::int64_t() const;
   operator float() const;
   operator double() const;
   operator std::string() const;
@@ -68,10 +69,10 @@ class DYNAMIC_GRAPH_DLLAPI Value {
   ~Value();
   void deleteValue();
   explicit Value(const bool &value);
-  explicit Value(const uint32_t &value);
-  explicit Value(const uint64_t &value);
-  explicit Value(const int32_t &value);
-  explicit Value(const int64_t &value);
+  explicit Value(const std::uint32_t &value);
+  explicit Value(const std::uint64_t &value);
+  explicit Value(const std::int32_t &value);
+  explicit Value(const std::int64_t &value);
   explicit Value(const float &value);
   explicit Value(const double &value);
   explicit Value(const std::string &value);
@@ -112,10 +113,10 @@ class DYNAMIC_GRAPH_DLLAPI Value {
  public:
   friend class EitherType;
   bool boolValue() const;
-  uint32_t unsignedValue() const;
-  uint64_t unsignedlongintValue() const;
-  int32_t intValue() const;
-  int64_t longintValue() const;
+  std::uint32_t unsignedValue() const;
+  std::uint64_t unsignedlongintValue() const;
+  std::int32_t intValue() const;
+  std::int64_t longintValue() const;
   float floatValue() const;
   double doubleValue() const;
   std::string stringValue() const;

--- a/include/dynamic-graph/value.h
+++ b/include/dynamic-graph/value.h
@@ -9,8 +9,8 @@
 
 #include <dynamic-graph/linear-algebra.h>
 
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <typeinfo>
 #include <vector>

--- a/src/command/value.cpp
+++ b/src/command/value.cpp
@@ -22,7 +22,9 @@ EitherType::~EitherType() {
 
 EitherType::operator bool() const { return value_->boolValue(); }
 EitherType::operator std::uint32_t() const { return value_->unsignedValue(); }
-EitherType::operator std::uint64_t() const { return value_->unsignedlongintValue(); }
+EitherType::operator std::uint64_t() const {
+  return value_->unsignedlongintValue();
+}
 EitherType::operator std::int32_t() const { return value_->intValue(); }
 EitherType::operator std::int64_t() const { return value_->longintValue(); }
 EitherType::operator float() const { return value_->floatValue(); }
@@ -87,7 +89,8 @@ Value::Value(const std::uint32_t &value)
     : type_(UNSIGNED), value_(new std::uint32_t(value)) {}
 Value::Value(const std::uint64_t &value)
     : type_(UNSIGNEDLONGINT), value_(new std::uint64_t(value)) {}
-Value::Value(const std::int32_t &value) : type_(INT), value_(new std::int32_t(value)) {}
+Value::Value(const std::int32_t &value)
+    : type_(INT), value_(new std::int32_t(value)) {}
 Value::Value(const std::int64_t &value)
     : type_(LONGINT), value_(new int64_t(value)) {}
 Value::Value(const float &value) : type_(FLOAT), value_(new float(value)) {}

--- a/src/command/value.cpp
+++ b/src/command/value.cpp
@@ -21,10 +21,10 @@ EitherType::~EitherType() {
 }
 
 EitherType::operator bool() const { return value_->boolValue(); }
-EitherType::operator uint32_t() const { return value_->unsignedValue(); }
-EitherType::operator uint64_t() const { return value_->unsignedlongintValue(); }
-EitherType::operator int32_t() const { return value_->intValue(); }
-EitherType::operator int64_t() const { return value_->longintValue(); }
+EitherType::operator std::uint32_t() const { return value_->unsignedValue(); }
+EitherType::operator std::uint64_t() const { return value_->unsignedlongintValue(); }
+EitherType::operator std::int32_t() const { return value_->intValue(); }
+EitherType::operator std::int64_t() const { return value_->longintValue(); }
 EitherType::operator float() const { return value_->floatValue(); }
 EitherType::operator double() const { return value_->doubleValue(); }
 EitherType::operator std::string() const { return value_->stringValue(); }
@@ -40,16 +40,16 @@ void Value::deleteValue() {
       delete (const bool *)value_;
       break;
     case UNSIGNED:
-      delete (const uint32_t *)value_;
+      delete (const std::uint32_t *)value_;
       break;
     case UNSIGNEDLONGINT:
-      delete (const uint64_t *)value_;
+      delete (const std::uint64_t *)value_;
       break;
     case INT:
-      delete (const int32_t *)value_;
+      delete (const std::int32_t *)value_;
       break;
     case LONGINT:
-      delete (const int64_t *)value_;
+      delete (const std::int64_t *)value_;
       break;
     case FLOAT:
       delete (const float *)value_;
@@ -83,12 +83,12 @@ void Value::deleteValue() {
 Value::~Value() { deleteValue(); }
 
 Value::Value(const bool &value) : type_(BOOL), value_(new bool(value)) {}
-Value::Value(const uint32_t &value)
-    : type_(UNSIGNED), value_(new uint32_t(value)) {}
-Value::Value(const uint64_t &value)
-    : type_(UNSIGNEDLONGINT), value_(new uint64_t(value)) {}
-Value::Value(const int32_t &value) : type_(INT), value_(new int32_t(value)) {}
-Value::Value(const int64_t &value)
+Value::Value(const std::uint32_t &value)
+    : type_(UNSIGNED), value_(new std::uint32_t(value)) {}
+Value::Value(const std::uint64_t &value)
+    : type_(UNSIGNEDLONGINT), value_(new std::uint64_t(value)) {}
+Value::Value(const std::int32_t &value) : type_(INT), value_(new std::int32_t(value)) {}
+Value::Value(const std::int64_t &value)
     : type_(LONGINT), value_(new int64_t(value)) {}
 Value::Value(const float &value) : type_(FLOAT), value_(new float(value)) {}
 Value::Value(const double &value) : type_(DOUBLE), value_(new double(value)) {}
@@ -206,25 +206,25 @@ bool Value::boolValue() const {
   throw ExceptionAbstract(ExceptionAbstract::TOOLS, "value is not an bool");
 }
 
-uint32_t Value::unsignedValue() const {
-  if (type_ == UNSIGNED) return *((const uint32_t *)value_);
+std::uint32_t Value::unsignedValue() const {
+  if (type_ == UNSIGNED) return *((const std::uint32_t *)value_);
   throw ExceptionAbstract(ExceptionAbstract::TOOLS,
                           "value is not an unsigned int");
 }
 
-uint64_t Value::unsignedlongintValue() const {
-  if (type_ == UNSIGNEDLONGINT) return *((const uint64_t *)value_);
+std::uint64_t Value::unsignedlongintValue() const {
+  if (type_ == UNSIGNEDLONGINT) return *((const std::uint64_t *)value_);
   throw ExceptionAbstract(ExceptionAbstract::TOOLS,
                           "value is not an unsigned long int");
 }
 
-int64_t Value::longintValue() const {
-  if (type_ == LONGINT) return *((const int64_t *)value_);
+std::int64_t Value::longintValue() const {
+  if (type_ == LONGINT) return *((const std::int64_t *)value_);
   throw ExceptionAbstract(ExceptionAbstract::TOOLS, "value is not an long int");
 }
 
-int32_t Value::intValue() const {
-  if (type_ == INT) return *((const int32_t *)value_);
+std::int32_t Value::intValue() const {
+  if (type_ == INT) return *((const std::int32_t *)value_);
   throw ExceptionAbstract(ExceptionAbstract::TOOLS, "value is not an int");
 }
 
@@ -356,13 +356,13 @@ std::ostream &operator<<(std::ostream &os, const Value &value) {
 template <>
 const Value::Type ValueHelper<bool>::TypeID = Value::BOOL;
 template <>
-const Value::Type ValueHelper<uint32_t>::TypeID = Value::UNSIGNED;
+const Value::Type ValueHelper<std::uint32_t>::TypeID = Value::UNSIGNED;
 template <>
-const Value::Type ValueHelper<uint64_t>::TypeID = Value::UNSIGNEDLONGINT;
+const Value::Type ValueHelper<std::uint64_t>::TypeID = Value::UNSIGNEDLONGINT;
 template <>
-const Value::Type ValueHelper<int32_t>::TypeID = Value::INT;
+const Value::Type ValueHelper<std::int32_t>::TypeID = Value::INT;
 template <>
-const Value::Type ValueHelper<int64_t>::TypeID = Value::LONGINT;
+const Value::Type ValueHelper<std::int64_t>::TypeID = Value::LONGINT;
 template <>
 const Value::Type ValueHelper<float>::TypeID = Value::FLOAT;
 template <>


### PR DESCRIPTION
Using ```unsigned long``` on ```x86_64-apple-darwin13.4.0-clang++``` generates an ambiguity.
This does not happen when using ```uint64_t```.
This PR fixes this problem.