### PR TITLE
Minor fix on Doxygen file format

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -395,12 +395,6 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# If the alphabetical index is enabled (see ALPHABETICAL_INDEX) then
-# the COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns
-# in which this list will be split (can be a number in the range [1..20])
-
-COLS_IN_ALPHA_INDEX    = 4
-
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Fix a deprecation warning on doxygen:
```
warning: Tag 'COLS_IN_ALPHA_INDEX' at line 303 of file 'Doxyfile' has become obsolete
```

Testing a full update on the file ```Doxygen.extra.in``` did not succeed because of the mixup with the internal Doxygen CMake extensions.